### PR TITLE
Fixed non-latin fatal exception

### DIFF
--- a/report.py
+++ b/report.py
@@ -34,7 +34,7 @@ class report(object):
         global indexiter
         #If file with filename does not exist (This happens in most of the cases)
         if not os.path.exists(self.filename):
-            self.f= open(self.filename,"w+")
+            self.f= open(self.filename,"w+",encoding='utf8')
         else:
             #Check for indexes if filename already exists in folder
             for indexcheck in range(1,indexiter):
@@ -57,6 +57,7 @@ MIT License.\n\
 -->\n\
 <head>\n\
 <title>Folder Sort Report</title>\n\
+<meta charset=\"UTF-8\">\n\
 <style>\n\
 table {\n\
     \tfont-family: arial, sans-serif;\n\


### PR DESCRIPTION
The exception was being caused by report.py, which could not parse UTF-8.

Both the file handling and HTML files were changed to UTF-8 encoding.

Tested on Windows 10, Python 3.5.2 with Russian and Japanese (Kanji) characters in file names.